### PR TITLE
Allow pilots in schedule slot to be removed, not just replaced, when a mission is also in the slot. 

### DIFF
--- a/Assets/Scripts/UI/Terminal/PilotsUI/PilotInMissionScheduleSlot.cs
+++ b/Assets/Scripts/UI/Terminal/PilotsUI/PilotInMissionScheduleSlot.cs
@@ -44,7 +44,7 @@ public class PilotInMissionScheduleSlot : MonoBehaviour, IPointerClickHandler
                 MissionsManager.RemoveScheduledMission(scheduled);
             }
 
-            // Ship goes back into the queue as it's not longer needed.
+            // Ship goes back into the queue as it's no longer needed.
             HangarManager.LaunchShip(scheduleSlot.hangarNode);
 
             Destroy(gameObject);


### PR DESCRIPTION
Before you could replace the pilot (choose a new one), but you had to remove the mission first before removing the pilot from the schedule slot.