### PR TITLE
Fixed bug where the repairs workstation kept spinning after you tabbed out

### DIFF
--- a/Assets/Scripts/Minigames/ShipRepairs/RepairsManager.cs
+++ b/Assets/Scripts/Minigames/ShipRepairs/RepairsManager.cs
@@ -16,6 +16,11 @@ public class RepairsManager : MonoBehaviour
         repairsUI = GetComponentInParent<RepairsUI>();
     }
 
+    private void OnDisable()
+    {
+        workstation.ResetWorkstation();
+    }
+
     public void StopStart()
     {
         if (workstation.isRotating)

--- a/Assets/Scripts/Minigames/ShipRepairs/Workstation.cs
+++ b/Assets/Scripts/Minigames/ShipRepairs/Workstation.cs
@@ -45,6 +45,12 @@ public class Workstation : MonoBehaviour
     public void ReverseRotationDirection() =>
         isDirectionReversed = !isDirectionReversed;
 
+    public void ResetWorkstation()
+    {
+        StopRotating();
+        transform.localEulerAngles = Vector3.zero;
+    }
+
     private void Update()
     {
         if (isRotating)


### PR DESCRIPTION
Reset repair workstation when tabbing out of repairs UI